### PR TITLE
Use `create()` factory method on paste

### DIFF
--- a/src/Frontend/FileHandler.js
+++ b/src/Frontend/FileHandler.js
@@ -36,7 +36,7 @@ export class FileHandler {
 
       try {
         const detected = AutoFormat.from(text)
-        const data = new ChaptersJson(detected)
+        const data = ChaptersJson.create(detected, detected.duration)
         gtag('event', 'ui', {
           action: 'external',
           origin: 'paste',


### PR DESCRIPTION
So far I've only tested this with pasting chapter lists from YouTube description, but it appears to work without issue.

Fixes #21 